### PR TITLE
[#57] 검색화면에서 발생하는 버그 수정

### DIFF
--- a/MinGenie/MinGenie/Search/MusicSearchView.swift
+++ b/MinGenie/MinGenie/Search/MusicSearchView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 
 struct MusicSearchView: View {
-    @ObservedObject private var model = MusicSearchModel()
+    @StateObject private var model = MusicSearchModel()
     
     @State private var selectedCategory: Category = .song
     @Binding var searchTerm: String


### PR DESCRIPTION
## 📝 작업 내용

검색 화면에서 노래 재생하면 검색 화면 결과 사라지는 현상이 있었음.

원인 : 
> 1. 공통으로 사용하는 model이 `@ObservedObject`로 선언되어 있음. -> 관찰되고 있기 때문에 값이 바뀌면 뷰도 새로 그림.
> 2. 사용자가 개별 곡 선택하면 로컬에 데이터를 `insert`하는 과정에서 view가 새로 그려짐. -> 검색 결과 날아감.

</br>

해결 :
> `@ObservedObject`로 선언되어 있는 모델을 `@StateObject`로 바꿈.

</br>

|문제 화면|해결 화면|
|:-:|:-:|
|<img src="https://github.com/user-attachments/assets/e2a4655a-9209-4722-8041-ce173b7a7cc0" width=300>|<img src="https://github.com/user-attachments/assets/53b50516-2669-49b7-a036-d5564a9a515f" width=300>

