### PR TITLE
[#114] Album cover 안보이는 이슈 해결

### DIFF
--- a/MinGenie/MinGenie.xcodeproj/xcshareddata/xcschemes/MinGenie.xcscheme
+++ b/MinGenie/MinGenie.xcodeproj/xcshareddata/xcschemes/MinGenie.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/MinGenie/MinGenie/ContentView.swift
+++ b/MinGenie/MinGenie/ContentView.swift
@@ -11,9 +11,9 @@ import SwiftUI
 
 struct ContentView: View {
     @Environment(\.scenePhase) var phase
+    @EnvironmentObject var musicPlayer: MusicPlayerModel
     
     @StateObject var shakeDetectionModel = ShakeDetectionModel()
-    @StateObject var musicPlayerModel = MusicPlayerModel.shared
     
     @AppStorage("Onboarding") var hasSeenOnboarding = false
     @AppStorage("BackgroundInfo") var hasSeenBackgroundInfoView = false
@@ -23,16 +23,16 @@ struct ContentView: View {
             ZStack(alignment: .bottom) {
                 HomeView()
                     .modelContainer(for: StoredTrackID.self)
-                    .environmentObject(musicPlayerModel)
+                    .environmentObject(musicPlayer)
                     .onChange(of: phase) { _, newValue in
-                        if newValue == .background && musicPlayerModel.isPlaying {
+                        if newValue == .background && musicPlayer.isPlaying {
                             shakeDetectionModel.startDetection()
                         } else {
                             shakeDetectionModel.stopDetection()
                         }
                     }
                     .onChange(of: shakeDetectionModel.shakeDetected) { _, newValue in
-                        if newValue && musicPlayerModel.isPlaying {
+                        if newValue && musicPlayer.isPlaying {
                             print("🎧 Music Change")
                             
                             AudioServicesPlaySystemSound(kSystemSoundID_Vibrate) //진동 주기
@@ -40,7 +40,7 @@ struct ContentView: View {
                             // 노래 교체가 끝나면 다시 시작
                             shakeDetectionModel.stopDetection()
                             Task {
-                                await musicPlayerModel.updatePlaylistAfterShaking()
+                                await musicPlayer.updatePlaylistAfterShaking()
                                 if phase == .background {
                                     shakeDetectionModel.startDetection()
                                 }

--- a/MinGenie/MinGenie/MinGenieApp.swift
+++ b/MinGenie/MinGenie/MinGenieApp.swift
@@ -10,10 +10,12 @@ import SwiftUI
 
 @main
 struct MinGenieApp: App {
-
+    @StateObject var musicPlayerModel = MusicPlayerModel()
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(musicPlayerModel)
         }
     }
 }

--- a/MinGenie/MinGenie/Playback/Cells/NowQueueItemCell.swift
+++ b/MinGenie/MinGenie/Playback/Cells/NowQueueItemCell.swift
@@ -27,18 +27,14 @@ struct NowQueueItemCell: View {
     // MARK: - View
     var body: some View {
         HStack {
-            
             if let itemArtwork = artwork {
                 imageContainer(for: itemArtwork)
                     .frame(width: artworkSize, height: artworkSize)
             } else {
-                
                     Image("FlowishGray")
                         .resizable()
                         .frame(width: artworkSize, height: artworkSize)
             }
-            
-            
             
             VStack(alignment: .leading) {
                 Text(title)

--- a/MinGenie/MinGenie/Playback/Cells/NowQueueItemCell.swift
+++ b/MinGenie/MinGenie/Playback/Cells/NowQueueItemCell.swift
@@ -4,9 +4,9 @@ import SwiftUI
 /// A view that displays information about a music item.
 struct NowQueueItemCell: View {
     // MARK: - Properties
-    private var artworkSize: CGFloat = 51
-    private var artworkCornerRadius: CGFloat = 11
-    private var subtitleVerticalOffset: CGFloat = -8
+    private let artworkSize: CGFloat = 51
+    private let artworkCornerRadius: CGFloat = 11
+    private let subtitleVerticalOffset: CGFloat = -8
     
     let artwork: Artwork?
     let title: String

--- a/MinGenie/MinGenie/Playback/MiniPlayerView.swift
+++ b/MinGenie/MinGenie/Playback/MiniPlayerView.swift
@@ -4,14 +4,10 @@ import SwiftUI
 /// ✏️ 하단에 띄워 둘 미니플레이어 View입니다 (완성) ✏️
 
 struct MiniPlayerView: View {
-    
-    /// musicPlayer 관련 변수
-    @ObservedObject private var playbackQueue = ApplicationMusicPlayer.shared.queue
-    @ObservedObject private var musicPlayer = MusicPlayerModel.shared
+    @EnvironmentObject var musicPlayer: MusicPlayerModel
     
     /// fullscreen전환 관련 변수
     @State private var isShowingNowPlaying = false
-    
     
     // MARK: - View
     var body: some View {
@@ -25,13 +21,13 @@ struct MiniPlayerView: View {
                     .shadow(radius: 20)
             )
             .fullScreenCover(isPresented: $isShowingNowPlaying) {
-                NowPlayingView(playbackQueue: playbackQueue)
+                NowPlayingView()
             }
     }
     
     @ViewBuilder
     private var content: some View {
-        if let currentPlayerEntry = playbackQueue.currentEntry {
+        if let currentPlayerEntry = musicPlayer.playbackQueue.currentEntry {
             HStack {
                 VStack(alignment: .leading){
                     Button(action: handleTap) {

--- a/MinGenie/MinGenie/Playback/MusicPlayerModel.swift
+++ b/MinGenie/MinGenie/Playback/MusicPlayerModel.swift
@@ -10,6 +10,7 @@ final class MusicPlayerModel: ObservableObject {
     // MARK: - Properties
     @Published var isPlaying = false
     @Published var playbackQueue = ApplicationMusicPlayer.shared.queue
+    @Published var currentMusicIndex: Int = 0
     
     var playbackStateObserver: AnyCancellable?
     

--- a/MinGenie/MinGenie/Playback/MusicPlayerModel.swift
+++ b/MinGenie/MinGenie/Playback/MusicPlayerModel.swift
@@ -3,9 +3,6 @@ import MusicKit
 import SwiftUI
 
 final class MusicPlayerModel: ObservableObject {
-    static let shared = MusicPlayerModel()
-    
-    private init() {}
     
     // MARK: - Properties
     @Published var isPlaying = false

--- a/MinGenie/MinGenie/Playback/MusicPlayerModel.swift
+++ b/MinGenie/MinGenie/Playback/MusicPlayerModel.swift
@@ -248,7 +248,9 @@ final class MusicPlayerModel: ObservableObject {
     }
     
     private func handlePlaybackStateDidChange() {
-        isPlaying = (musicPlayer.state.playbackStatus == .playing)
+        DispatchQueue.main.async {
+            self.isPlaying = (self.musicPlayer.state.playbackStatus == .playing)
+        }
     }
     
 }

--- a/MinGenie/MinGenie/Playback/NowPlayingView.swift
+++ b/MinGenie/MinGenie/Playback/NowPlayingView.swift
@@ -2,10 +2,7 @@ import MusicKit
 import SwiftUI
 
 struct NowPlayingView: View {
-    
-    ///Music Player관련
-    @ObservedObject var playbackQueue: ApplicationMusicPlayer.Queue
-    @ObservedObject private var musicPlayer = MusicPlayerModel.shared
+    @EnvironmentObject var musicPlayer: MusicPlayerModel
     
     ///FullScreen Dismiss 관련
     @Environment(\.presentationMode) var presentation
@@ -16,7 +13,7 @@ struct NowPlayingView: View {
         NavigationView {
             
             VStack(spacing: 0) {
-                DismissButton { FullScreenDismiss() }
+                DismissButton { fullScreenDismiss() }
                     .padding(.bottom, 10)
                 HStack {
                     Text("Flowish")
@@ -42,13 +39,13 @@ struct NowPlayingView: View {
         .gesture(
             DragGesture().onEnded { value in
                 if value.translation.height > 150 {
-                    FullScreenDismiss()
+                    fullScreenDismiss()
                 }
             }
         )
         .onAppear {
             /// onAppear시, entries에서의 index와 캐러셀의 index를 일치시켜줘요!
-            if let savedEntryIndex = playbackQueue.entries.firstIndex(where: { $0.id == playbackQueue.currentEntry?.id }) {
+            if let savedEntryIndex = musicPlayer.playbackQueue.entries.firstIndex(where: { $0.id == musicPlayer.playbackQueue.currentEntry?.id }) {
                 musicPlayer.currentMusicIndex = savedEntryIndex
             }
             /// entries에 아무것도 안담겨 있으면 index 0으로 초기화해요!
@@ -57,9 +54,9 @@ struct NowPlayingView: View {
             }
         }
         /// fullScreen일때, 현재재생곡이 넘어가면 캐러셀이 전환되는 부분입니다!
-        .onChange(of: playbackQueue.currentEntry) { _, entry in
+        .onChange(of: musicPlayer.playbackQueue.currentEntry) { _, entry in
             /// 또 전수검사 해줘요..
-            if let entry = entry, let newIndex = playbackQueue.entries.firstIndex(where: { $0.id == entry.id }) {
+            if let entry = entry, let newIndex = musicPlayer.playbackQueue.entries.firstIndex(where: { $0.id == entry.id }) {
                 musicPlayer.currentMusicIndex = newIndex
             }
         }
@@ -69,12 +66,12 @@ struct NowPlayingView: View {
     private var QueueView: some View {
         ZStack {
             Color.BG.main.ignoresSafeArea(.all)
-            Queuelist(for: playbackQueue)
+            QueueList(for: musicPlayer.playbackQueue)
         }
     }
     
     @ViewBuilder
-    private func Queuelist(for playbackQueue: ApplicationMusicPlayer.Queue) -> some View {
+    private func QueueList(for playbackQueue: ApplicationMusicPlayer.Queue) -> some View {
         ScrollViewReader { proxy in
             List {
                 ForEach(playbackQueue.entries.indices, id: \.self) { index in
@@ -117,10 +114,11 @@ struct NowPlayingView: View {
     
     @ViewBuilder
     private var CarouselView: some View {
-        Carousellist(for: playbackQueue)
+        CarouselList(for: musicPlayer.playbackQueue)
     }
     
-    private func Carousellist(for playbackQueue: ApplicationMusicPlayer.Queue) -> some View {
+    @ViewBuilder
+     private func CarouselList(for playbackQueue: ApplicationMusicPlayer.Queue) -> some View {
         
         NavigationStack {
             ZStack {
@@ -204,7 +202,7 @@ struct NowPlayingView: View {
         musicPlayer.togglePlaybackStatus()
     }
     
-    private func FullScreenDismiss() {
+    private func fullScreenDismiss() {
         presentation.wrappedValue.dismiss()
     }
     

--- a/MinGenie/MinGenie/Playback/NowPlayingView.swift
+++ b/MinGenie/MinGenie/Playback/NowPlayingView.swift
@@ -76,7 +76,7 @@ struct NowPlayingView: View {
             List {
                 ForEach(playbackQueue.entries.indices, id: \.self) { index in
                     NowQueueItemCell(
-                        artwork: playbackQueue.entries[index].artwork,
+                        artwork: musicPlayer.queueTracks[index].artwork,
                         title: playbackQueue.entries[index].title,
                         subtitle: playbackQueue.entries[index].subtitle
                     )
@@ -133,7 +133,7 @@ struct NowPlayingView: View {
                             if startIndex <= endIndex {
                                 ForEach(startIndex...endIndex, id: \.self) { index in
                                     
-                                    imageContainer(for: playbackQueue.entries[index].artwork)
+                                    imageContainer(for: musicPlayer.queueTracks[index].artwork)
                                         .scaleEffect(1.0 - CGFloat(abs(index - musicPlayer.currentMusicIndex)) * 0.1)
                                         .zIndex(1.0 - Double(abs(index - musicPlayer.currentMusicIndex)))
                                         .offset(x: CGFloat(index - musicPlayer.currentMusicIndex) * 50 * (1 - CGFloat(abs(index - musicPlayer.currentMusicIndex)) * 0.1) + dragOffset, y: 0)

--- a/MinGenie/MinGenie/Playback/NowPlayingView.swift
+++ b/MinGenie/MinGenie/Playback/NowPlayingView.swift
@@ -21,8 +21,7 @@ struct NowPlayingView: View {
     var body: some View {
         /// 전체 View 구성
         NavigationView {
-            //            ZStack {
-            //                Color.BG.main.ignoresSafeArea(.all)
+            
             VStack(spacing: 0) {
                 DismissButton { FullScreenDismiss() }
                     .padding(.bottom, 10)
@@ -36,30 +35,15 @@ struct NowPlayingView: View {
                 
                 ZStack {
                     CarouselView
-//                        .padding(30)
-                    //                        .padding(.top, 20)
                     pauseButton
                         .padding(.bottom, -20)
                 }
-                                                .frame(height: 360)
-//                .background(.red)
+                .frame(height: 360)
                 
                 QueueView
             }
             .background(Color.BG.main)
-            
-            //                VStack {
-            //                    Text("못할 것도 없지 화이팅🔥")
-            //                        .font(.system(size: 34, weight: .black))
-            //                        .foregroundStyle(Color.Text.blue)
-            //                }
-            //                .padding(.leading, -18)
-            //                .padding(.top, -345)
-            
-            
         }
-        
-        //        }
         
         /// FullScreenDismiss 드래그 감지
         .gesture(
@@ -86,7 +70,6 @@ struct NowPlayingView: View {
                 currentIndex = newIndex
             }
         }
-        
     }
     
     @ViewBuilder
@@ -96,6 +79,7 @@ struct NowPlayingView: View {
             Queuelist(for: playbackQueue)
         }
     }
+    
     @ViewBuilder
     private func Queuelist(for playbackQueue: ApplicationMusicPlayer.Queue) -> some View {
         ScrollViewReader { proxy in
@@ -116,6 +100,7 @@ struct NowPlayingView: View {
             }
             .background(Color.BG.main)
             .listStyle(.plain)
+            
             ///비활성화되어있을 때 곡이 넘어가도, 켜면 바로 그 곡으로 스크롤되도록!
             .onAppear {
                 if let entry = playbackQueue.currentEntry, let newIndex = playbackQueue.entries.firstIndex(where: { $0.id == entry.id }) {
@@ -250,7 +235,6 @@ struct NowPlayingView: View {
     
     private func imageContainer(for artwork: Artwork?) -> some View {
         VStack {
-            //            Spacer()
             if let artwork = artwork {
                 ZStack {
                     ArtworkImage(artwork, width: 244, height: 244)
@@ -269,7 +253,6 @@ struct NowPlayingView: View {
                     .cornerRadius(16)
                     .shadow(radius: 4)
             }
-            //            Spacer()
         }
     }
 }

--- a/MinGenie/MinGenie/Playback/NowPlayingView.swift
+++ b/MinGenie/MinGenie/Playback/NowPlayingView.swift
@@ -1,8 +1,6 @@
 import MusicKit
 import SwiftUI
 
-/// ✏️ 현재 재생 View입니다 (수정중) ✏️
-
 struct NowPlayingView: View {
     
     ///Music Player관련
@@ -12,11 +10,6 @@ struct NowPlayingView: View {
     ///FullScreen Dismiss 관련
     @Environment(\.presentationMode) var presentation
     @GestureState private var dragOffset: CGFloat = 0
-    
-    ///Carousel 인덱스 관련
-    @AppStorage("currentIndex") private var currentIndex: Int = 0
-    
-    @State var idx = -1
     
     var body: some View {
         /// 전체 View 구성
@@ -56,18 +49,18 @@ struct NowPlayingView: View {
         .onAppear {
             /// onAppear시, entries에서의 index와 캐러셀의 index를 일치시켜줘요!
             if let savedEntryIndex = playbackQueue.entries.firstIndex(where: { $0.id == playbackQueue.currentEntry?.id }) {
-                currentIndex = savedEntryIndex
+                musicPlayer.currentMusicIndex = savedEntryIndex
             }
             /// entries에 아무것도 안담겨 있으면 index 0으로 초기화해요!
             else {
-                currentIndex = 0
+                musicPlayer.currentMusicIndex = 0
             }
         }
         /// fullScreen일때, 현재재생곡이 넘어가면 캐러셀이 전환되는 부분입니다!
         .onChange(of: playbackQueue.currentEntry) { _, entry in
             /// 또 전수검사 해줘요..
             if let entry = entry, let newIndex = playbackQueue.entries.firstIndex(where: { $0.id == entry.id }) {
-                currentIndex = newIndex
+                musicPlayer.currentMusicIndex = newIndex
             }
         }
     }
@@ -93,7 +86,7 @@ struct NowPlayingView: View {
                     .listRowBackground(Color.BG.main)
                     .onTapGesture {
                         playbackQueue.currentEntry = playbackQueue.entries[index]
-                        currentIndex = index
+                        musicPlayer.currentMusicIndex = index
                         if !musicPlayer.isPlaying { pausePlay() }
                     }
                 }
@@ -104,18 +97,18 @@ struct NowPlayingView: View {
             ///비활성화되어있을 때 곡이 넘어가도, 켜면 바로 그 곡으로 스크롤되도록!
             .onAppear {
                 if let entry = playbackQueue.currentEntry, let newIndex = playbackQueue.entries.firstIndex(where: { $0.id == entry.id }) {
-                    currentIndex = newIndex
+                    musicPlayer.currentMusicIndex = newIndex
                     withAnimation {
-                        proxy.scrollTo(currentIndex, anchor: .top)
+                        proxy.scrollTo(musicPlayer.currentMusicIndex, anchor: .top)
                     }
                 }
             }
             ///현재재생곡이 넘어가면 list가 스크롤되는 부분입니다!
             .onChange(of: playbackQueue.currentEntry) { _, entry in
                 if let entry = entry, let newIndex = playbackQueue.entries.firstIndex(where: { $0.id == entry.id }) {
-                    currentIndex = newIndex
+                    musicPlayer.currentMusicIndex = newIndex
                     withAnimation {
-                        proxy.scrollTo(currentIndex, anchor: .top)
+                        proxy.scrollTo(musicPlayer.currentMusicIndex, anchor: .top)
                     }
                 }
             }
@@ -136,19 +129,19 @@ struct NowPlayingView: View {
                 VStack {
                     ZStack {
                         if playbackQueue.entries.count > 0 {
-                            let startIndex = max(currentIndex - 2, 0)
-                            let endIndex = min(currentIndex + 2, playbackQueue.entries.count - 1)
+                            let startIndex = max(musicPlayer.currentMusicIndex - 2, 0)
+                            let endIndex = min(musicPlayer.currentMusicIndex + 2, playbackQueue.entries.count - 1)
                             
                             if startIndex <= endIndex {
                                 ForEach(startIndex...endIndex, id: \.self) { index in
                                     
                                     imageContainer(for: playbackQueue.entries[index].artwork)
-                                        .scaleEffect(1.0 - CGFloat(abs(index - currentIndex)) * 0.1)
-                                        .zIndex(1.0 - Double(abs(index - currentIndex)))
-                                        .offset(x: CGFloat(index - currentIndex) * 50 * (1 - CGFloat(abs(index - currentIndex)) * 0.1) + dragOffset, y: 0)
+                                        .scaleEffect(1.0 - CGFloat(abs(index - musicPlayer.currentMusicIndex)) * 0.1)
+                                        .zIndex(1.0 - Double(abs(index - musicPlayer.currentMusicIndex)))
+                                        .offset(x: CGFloat(index - musicPlayer.currentMusicIndex) * 50 * (1 - CGFloat(abs(index - musicPlayer.currentMusicIndex)) * 0.1) + dragOffset, y: 0)
                                         .padding(.top, -20)
                                     
-                                    if index == currentIndex {
+                                    if index == musicPlayer.currentMusicIndex {
                                         VStack(spacing: 0) {
                                             Text(playbackQueue.entries[index].title)
                                                 .font(.system(size: 20, weight: .bold))
@@ -184,15 +177,15 @@ struct NowPlayingView: View {
                     let threshold: CGFloat = 50
                     if value.translation.width > threshold {
                         withAnimation {
-                            currentIndex = max(0, currentIndex - 1)
+                            musicPlayer.currentMusicIndex = max(0, musicPlayer.currentMusicIndex - 1)
                         }
                     } else if value.translation.width < -threshold {
                         withAnimation {
-                            currentIndex = min(playbackQueue.entries.count - 1, currentIndex + 1)
+                            musicPlayer.currentMusicIndex = min(playbackQueue.entries.count - 1, musicPlayer.currentMusicIndex + 1)
                         }
                     }
                     /// 캐러셀 넘기면 currentEntry를 갈아치워요!
-                    playbackQueue.currentEntry = playbackQueue.entries[currentIndex]
+                    playbackQueue.currentEntry = playbackQueue.entries[musicPlayer.currentMusicIndex]
                 }
         )
     }


### PR DESCRIPTION
## 📝 작업 내용

### 플레이어 뷰에서 아트워크 이미지가 보이지 않는 이슈 해결
- **해결 방식:** queue에 음악을 넣으면서 관련 track을 배열에 따로 저장한 뒤, 해당 값의 아트워크에 접근하여 뷰에 보여줍니다. queue의 데이터 인덱스와 새롭게 만든 배열의 데이터 인덱스가 동일하기 때문에 가능합니다.

- **추가 작업:** 플레이어 모델의 observed object 참조 문제를 해결하기 위해 EnvironmentObject로 리팩토링하였습니다.

### 스크린샷 (선택)
|문제 영상|해결 영상|
|:---:|:---:|
|<img src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A3-BlackDragonRiver/assets/123877353/7b5261e0-f68f-4262-bf2d-cac5fa79d60c" width="200" height="400"/>|<img src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A3-BlackDragonRiver/assets/123877353/e8133232-369a-48e2-b4c3-04b66ccd9220" width="200" height="400"/>|

## 💬 리뷰 요구사항 (선택)

- 새롭게 만든 `queueTracks` 배열의 변수명이 적절한지 확인해주세요 🐯