### PR TITLE
[#124] gitignore 목록 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 
 ## User settings
 xcuserdata/
+!*.xcodeproj/xcshareddata/
+**/xcshareddata/WorkspaceSettings.xcsettings
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint


### PR DESCRIPTION
## Description

<img width="500" alt="image" src="https://github.com/user-attachments/assets/3d856e77-30a8-447e-ab6d-12874fd27d9e">

</br>  
  </br>  

`xcshareddata/WorkspaceSettings.xcsettings`이 계속 뜸.
`git stash` 명령어 적용되지 않음.
어떤 파일인지 찾아봤더니, 개인화된 개발 환경에 대한 설정이기 때문에 repo에 올리지 않아도 된다는 정보를 알게 됨.
repo에 올리지 않아도 되는 불필요한 파일이므로 `gitignore` 목록에 추가하려고 한다.

## To-do

- [x] `gitignore` 목록에 `**/xcshareddata/WorkspaceSettings.xcsettings` 추가하기

## ETC (참고 자료)

> gpt 문의 결과 . . .
> 
> <img width="500" alt="image" src="https://github.com/user-attachments/assets/32cd7134-48be-4c3d-987c-b3973f2418f5">
